### PR TITLE
feat: Add OI Tracker Strategy

### DIFF
--- a/brokers/zerodha.py
+++ b/brokers/zerodha.py
@@ -160,6 +160,8 @@ class ZerodhaBroker(BrokerBase):
     def get_quote(self, symbol):
         return self.kite.quote(symbol)
     
+    def get_historical_data(self, instrument_token, from_date, to_date, interval, oi=False):
+        return self.kite.historical_data(instrument_token, from_date, to_date, interval, oi=oi)
 
     def get_positions(self):
         return self.kite.positions()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,6 @@ dependencies = [
     "pyyaml>=6.0.2",
     "ratelimit>=2.2.1",
     "requests>=2.31.0",
+    "rich>=13.7.1",
+    "beepy==1.0.9",
 ]

--- a/strategy/configs/oi_tracker.yml
+++ b/strategy/configs/oi_tracker.yml
@@ -1,0 +1,47 @@
+# OI Tracker Strategy Configuration
+# =============================================
+#
+# This configuration file defines parameters for the OI Tracker Strategy, which monitors
+# Open Interest (OI) changes for NIFTY options.
+
+default:
+  # ========================================================================
+  # CORE PARAMETERS
+  # ========================================================================
+
+  # Underlying index symbol for price tracking
+  index_symbol: "NSE:NIFTY 50"
+
+  # Option series identifier prefix (e.g., 'NIFTYYYMMDD' for monthly/weekly expiries)
+  # This needs to be updated to the current expiry series you want to track.
+  # For example, for the August 2024 monthly expiry, it might be 'NIFTY248'.
+  # For a weekly expiry on Aug 8th, it could be 'NIFTY24808'.
+  symbol_initials: "NIFTY24AUG"
+
+  # Number of ITM/OTM strikes to track on each side of the ATM strike.
+  # For example, a value of 2 will track ATM-2, ATM-1, ATM, ATM+1, ATM+2.
+  strike_count: 2
+
+  # The difference between consecutive strike prices for NIFTY
+  nifty_strike_difference: 50
+
+  # Update interval in seconds
+  update_interval_seconds: 60
+
+  # ========================================================================
+  # UI AND ALERT PARAMETERS
+  # ========================================================================
+
+  # Percentage thresholds for color-coding cells red.
+  # If the change in OI for a given time interval exceeds this value, the cell turns red.
+  color_thresholds:
+    m3: 10  # > 10% change in 3 minutes
+    m5: 12  # > 12% change in 5 minutes
+    m10: 15 # > 15% change in 10 minutes
+    m15: 30 # > 30% change in 15 minutes
+    m30: 30 # > 30% change in 30 minutes
+    h3: 100 # > 100% change in 3 hours
+
+  # The threshold for the sound alert.
+  # If the percentage of red-colored cells in any table exceeds this value, a sound will play.
+  alert_threshold_percentage: 30

--- a/strategy/oi_tracker.py
+++ b/strategy/oi_tracker.py
@@ -1,0 +1,343 @@
+import os
+import sys
+import time
+import yaml
+import argparse
+import datetime
+from queue import Queue
+import traceback
+import warnings
+
+from rich.console import Console
+from rich.live import Live
+from rich.table import Table
+import beepy
+
+# Add project root to path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from logger import logger
+from brokers.zerodha import ZerodhaBroker
+
+warnings.filterwarnings("ignore")
+
+class OITrackerStrategy:
+    """
+    OI Tracker Strategy
+
+    This strategy tracks the Open Interest (OI) changes for NIFTY options
+    at different time intervals and displays them in a live-updating table.
+    """
+
+    def __init__(self, broker, config):
+        """
+        Initializes the OITrackerStrategy.
+
+        Args:
+            broker (ZerodhaBroker): An instance of the ZerodhaBroker.
+            config (dict): A dictionary containing the strategy configuration.
+        """
+        self.broker = broker
+        self.config = config
+
+        # Load config values
+        for k, v in config.items():
+            setattr(self, f'strat_var_{k}', v)
+
+        self.broker.download_instruments()
+        self.instruments_df = self.broker.get_instruments()
+
+        # Filter for NFO instruments
+        self.nfo_instruments = self.instruments_df[self.instruments_df['segment'] == 'NFO-OPT']
+
+        # Filter for the specific option series
+        self.option_series_instruments = self.nfo_instruments[
+            self.nfo_instruments['tradingsymbol'].str.startswith(self.strat_var_symbol_initials)
+        ]
+
+        if self.option_series_instruments.empty:
+            logger.error(f"No instruments found for symbol prefix: {self.strat_var_symbol_initials}")
+            sys.exit(1)
+
+        logger.info(f"Successfully loaded {len(self.option_series_instruments)} instruments for {self.strat_var_symbol_initials}")
+
+        self.instrument_data = {}
+
+    def _get_nifty_ltp(self):
+        """Fetches the last traded price and instrument token of NIFTY 50."""
+        try:
+            quote = self.broker.get_quote(self.strat_var_index_symbol)
+            ltp = quote[self.strat_var_index_symbol]['last_price']
+            token = quote[self.strat_var_index_symbol]['instrument_token']
+            return ltp, token
+        except Exception as e:
+            logger.error(f"Error fetching NIFTY LTP: {e}")
+            return None, None
+
+    def _get_atm_strike(self, ltp):
+        """Calculates the At-The-Money (ATM) strike based on the LTP."""
+        if ltp is None:
+            return None
+        strike_diff = self.strat_var_nifty_strike_difference
+        return round(ltp / strike_diff) * strike_diff
+
+    def _get_option_details(self, atm_strike):
+        """
+        Gets the instrument details for the required call and put options.
+
+        Args:
+            atm_strike (float): The current ATM strike price.
+
+        Returns:
+            tuple: A tuple containing two lists: (call_options, put_options)
+                   Each list contains dictionaries with instrument details.
+        """
+        if atm_strike is None:
+            return [], []
+
+        strikes_to_find = [atm_strike + i * self.strat_var_nifty_strike_difference for i in range(-self.strat_var_strike_count, self.strat_var_strike_count + 1)]
+
+        call_options = []
+        put_options = []
+
+        for strike in strikes_to_find:
+            # Find Call Option
+            call_instrument = self.option_series_instruments[
+                (self.option_series_instruments['strike'] == strike) &
+                (self.option_series_instruments['instrument_type'] == 'CE')
+            ]
+            if not call_instrument.empty:
+                call_options.append(call_instrument.iloc[0].to_dict())
+
+            # Find Put Option
+            put_instrument = self.option_series_instruments[
+                (self.option_series_instruments['strike'] == strike) &
+                (self.option_series_instruments['instrument_type'] == 'PE')
+            ]
+            if not put_instrument.empty:
+                put_options.append(put_instrument.iloc[0].to_dict())
+
+        # Sort by strike price
+        call_options.sort(key=lambda x: x['strike'])
+        put_options.sort(key=lambda x: x['strike'])
+
+        return call_options, put_options
+
+    def _update_historical_data(self, instruments_to_update):
+        """
+        Fetches and updates historical data for the given instruments.
+        """
+        to_date = datetime.datetime.now()
+        from_date = to_date - datetime.timedelta(hours=3, minutes=30) # A bit of buffer
+
+        for instrument in instruments_to_update:
+            token = instrument['instrument_token']
+            try:
+                records = self.broker.get_historical_data(
+                    instrument_token=token,
+                    from_date=from_date,
+                    to_date=to_date,
+                    interval='minute',
+                    oi=True
+                )
+                self.instrument_data[token] = records
+                logger.info(f"Updated historical data for {instrument['tradingsymbol']} ({len(records)} records)")
+            except Exception as e:
+                logger.error(f"Failed to fetch historical data for {instrument['tradingsymbol']}: {e}")
+                self.instrument_data[token] = [] # Store empty list on failure
+
+    def _calculate_change(self, token, minutes_ago, data_key='oi'):
+        """
+        Calculates the absolute and percentage change for a given instrument and time.
+        """
+        history = self.instrument_data.get(token, [])
+        if len(history) < 2:
+            return 0, 0.0, None # Not enough data
+
+        # Ensure history is sorted by date, most recent first
+        history.sort(key=lambda x: x['date'], reverse=True)
+
+        current_record = history[0]
+        current_value = current_record[data_key]
+
+        target_time = current_record['date'] - datetime.timedelta(minutes=minutes_ago)
+
+        # Find the closest record to the target time
+        past_record = min(history, key=lambda x: abs(x['date'] - target_time))
+
+        # Ensure we are not comparing the same record
+        if past_record['date'] == current_record['date'] and len(history) > 1:
+             past_record = history[1]
+
+
+        past_value = past_record[data_key]
+
+        if past_value == 0:
+            return 0, 0.0, "na" # Avoid division by zero
+
+        abs_change = current_value - past_value
+        perc_change = (abs_change / past_value) * 100
+
+        return abs_change, perc_change
+
+    def _generate_options_table(self, title, options, atm_strike):
+        """
+        Generates a table for call or put options.
+        Returns the table and the count of red cells.
+        """
+        table = Table(title=title, show_header=True, header_style="bold magenta")
+        table.add_column("Strike", style="dim", width=12)
+        table.add_column("Current OI", justify="right")
+        table.add_column("3min Δ", justify="right")
+        table.add_column("5min Δ", justify="right")
+        table.add_column("10min Δ", justify="right")
+        table.add_column("15min Δ", justify="right")
+        table.add_column("30min Δ", justify="right")
+        table.add_column("3hr Δ", justify="right")
+
+        time_intervals = {'3min': 3, '5min': 5, '10min': 10, '15min': 15, '30min': 30, '3hr': 180}
+        red_cell_count = 0
+        total_data_cells = 0
+
+        for option in options:
+            token = option['instrument_token']
+            history = self.instrument_data.get(token, [])
+            current_oi = history[0]['oi'] if history else 0
+
+            strike_style = "bold yellow" if option['strike'] == atm_strike else ""
+            row_data = [f"[{strike_style}]{option['strike']}[/{strike_style}]"]
+            row_data.append(f"{current_oi:,}")
+
+            for key, minutes in time_intervals.items():
+                total_data_cells += 1
+                abs_change, perc_change = self._calculate_change(token, minutes, 'oi')
+
+                # Determine style based on threshold
+                threshold = self.strat_var_color_thresholds.get(key.replace('min', 'm').replace('hr', 'h'), 1000)
+                style = ""
+                if perc_change > threshold:
+                    style = "red"
+                    red_cell_count += 1
+
+                cell_content = f"[{style}]{perc_change:+.1f}% ({abs_change:,})[/{style}]"
+                row_data.append(cell_content)
+
+            table.add_row(*row_data)
+
+        return table, red_cell_count, total_data_cells
+
+    def _generate_nifty_table(self, ltp, token):
+        """Generates a table for NIFTY value changes."""
+        table = Table(title="NIFTY", show_header=True, header_style="bold cyan")
+        table.add_column("Current Price", justify="right")
+        table.add_column("3min Δ", justify="right")
+        table.add_column("5min Δ", justify="right")
+        table.add_column("10min Δ", justify="right")
+        table.add_column("15min Δ", justify="right")
+        table.add_column("30min Δ", justify="right")
+        table.add_column("3hr Δ", justify="right")
+
+        time_intervals = {'3min': 3, '5min': 5, '10min': 10, '15min': 15, '30min': 30, '3hr': 180}
+
+        row_data = [f"{ltp:,.2f}"]
+
+        for key, minutes in time_intervals.items():
+            abs_change, perc_change = self._calculate_change(token, minutes, 'close')
+            cell_content = f"{perc_change:+.2f}% ({abs_change:,.2f})"
+            row_data.append(cell_content)
+
+        table.add_row(*row_data)
+        return table
+
+    def run(self):
+        """Starts the main loop of the strategy."""
+        console = Console()
+
+        with Live(console=console, screen=True, redirect_stderr=False) as live:
+            while True:
+                try:
+                    ltp, nifty_token = self._get_nifty_ltp()
+                    atm_strike = self._get_atm_strike(ltp)
+
+                    if not ltp or not atm_strike or not nifty_token:
+                        live.update("[bold red]Could not fetch NIFTY LTP. Retrying...[/bold red]")
+                        time.sleep(self.strat_var_update_interval_seconds)
+                        continue
+
+                    call_options, put_options = self._get_option_details(atm_strike)
+
+                    nifty_instrument = [{'instrument_token': nifty_token, 'tradingsymbol': 'NIFTY 50'}]
+                    all_instruments = nifty_instrument + call_options + put_options
+
+                    self._update_historical_data(all_instruments)
+
+                    # Generate tables
+                    calls_table, red_calls, total_calls = self._generate_options_table("CALLS", call_options, atm_strike)
+                    puts_table, red_puts, total_puts = self._generate_options_table("PUTS", put_options, atm_strike)
+                    nifty_table = self._generate_nifty_table(ltp, nifty_token)
+
+                    # Check for alerts
+                    total_red_cells = red_calls + red_puts
+                    total_data_cells = total_calls + total_puts
+                    if total_data_cells > 0:
+                        red_percentage = (total_red_cells / total_data_cells) * 100
+                        if red_percentage > self.strat_var_alert_threshold_percentage:
+                            beepy.beep(sound='ping')
+                            logger.warning(f"ALERT: Red cell percentage ({red_percentage:.1f}%) exceeded threshold.")
+
+                    # Group tables for display
+                    from rich.panel import Panel
+                    from rich.layout import Layout
+                    from rich.align import Align
+
+                    layout = Layout()
+                    layout.split(
+                        Layout(name="header", size=3),
+                        Layout(ratio=1, name="main"),
+                        Layout(size=3, name="footer")
+                    )
+
+                    header_text = Align.center(f"NIFTY @ {ltp:,.2f} (ATM: {atm_strike}) | Last updated: {datetime.datetime.now().strftime('%H:%M:%S')}", vertical="middle")
+                    layout["header"].update(header_text)
+
+                    layout["main"].split_row(Layout(name="left"), Layout(name="right"))
+                    layout["left"].update(calls_table)
+                    layout["right"].update(puts_table)
+
+                    layout["footer"].update(nifty_table)
+
+                    live.update(layout)
+
+                    time.sleep(self.strat_var_update_interval_seconds)
+
+                except KeyboardInterrupt:
+                    logger.info("Shutdown requested by user.")
+                    break
+            except Exception as e:
+                logger.error(f"An error occurred in the main loop: {e}")
+                traceback.print_exc()
+                time.sleep(self.strat_var_update_interval_seconds)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="OI Tracker Strategy")
+    parser.add_argument('--config', type=str, default='strategy/configs/oi_tracker.yml', help='Path to the configuration file.')
+    args = parser.parse_args()
+
+    try:
+        with open(args.config, 'r') as f:
+            config = yaml.safe_load(f)['default']
+        logger.info("Configuration loaded successfully.")
+    except Exception as e:
+        logger.error(f"Error loading configuration file: {e}")
+        sys.exit(1)
+
+    try:
+        broker = ZerodhaBroker(without_totp=True) # Assuming non-TOTP login for simplicity
+        logger.info("Broker initialized successfully.")
+    except Exception as e:
+        logger.error(f"Error initializing broker: {e}")
+        sys.exit(1)
+
+    strategy = OITrackerStrategy(broker, config)
+    strategy.run()

--- a/uv.lock
+++ b/uv.lock
@@ -121,6 +121,18 @@ wheels = [
 ]
 
 [[package]]
+name = "beepy"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "simpleaudio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/20/47236fc81b180636f5fcdfa025d00ec71fc7c509b6d991f2feef6e19cac3/beepy-1.0.9.tar.gz", hash = "sha256:05b2d6789abb43930069e1d96a56c9e8b0498378e09784cfe9a1dec02368fcab", size = 4271, upload-time = "2025-06-08T13:22:20.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/e5/b0d6f1501cf7c2fd8c9db520e55a3cffa486d5f763d8e40db82daaf77d04/beepy-1.0.9-py3-none-any.whl", hash = "sha256:22c104db011cf12f3420aaf145fff6e93b2f050c02d2eda83a66448f079d9cf2", size = 3923, upload-time = "2025-06-08T13:22:19.671Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.39.12"
 source = { registry = "https://pypi.org/simple" }
@@ -416,6 +428,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mibian"
 version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -661,6 +694,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
 name = "pyopenssl"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -776,6 +818,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
 name = "s3transfer"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -812,6 +867,12 @@ wheels = [
 ]
 
 [[package]]
+name = "simpleaudio"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/1b/4dc29653733202b68c09d9c6ca085cf67ac54859ee860647ef21ac1ff3dc/simpleaudio-1.0.4.tar.gz", hash = "sha256:691c88649243544db717e7edf6a9831df112104e1aefb5f6038a5d071e8cf41d", size = 2042564, upload-time = "2019-11-29T03:56:28.965Z" }
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -825,6 +886,7 @@ name = "trading-algo"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "beepy" },
     { name = "fyers-apiv3" },
     { name = "kiteconnect" },
     { name = "mibian" },
@@ -834,10 +896,12 @@ dependencies = [
     { name = "pyyaml" },
     { name = "ratelimit" },
     { name = "requests" },
+    { name = "rich" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "beepy", specifier = "==1.0.9" },
     { name = "fyers-apiv3", specifier = ">=3.1.7" },
     { name = "kiteconnect", specifier = ">=5.0.1" },
     { name = "mibian", specifier = ">=0.1.3" },
@@ -847,6 +911,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ratelimit", specifier = ">=2.2.1" },
     { name = "requests", specifier = ">=2.31.0" },
+    { name = "rich", specifier = ">=13.7.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit introduces a new strategy, OITrackerStrategy, to monitor and display Open Interest (OI) changes for NIFTY options.

The new strategy provides a live-updating terminal interface with three tables:
1.  Call Options: Shows OI changes for 5 strikes around the ATM.
2.  Put Options: Shows OI changes for 5 strikes around the ATM.
3.  NIFTY: Shows price changes for the NIFTY 50 index.

Key Features:
-   Calculates and displays OI/price changes for 3m, 5m, 10m, 15m, 30m, and 3hr intervals.
-   Color-codes cells in red based on configurable percentage change thresholds.
-   Plays a sound alert if the number of red-flagged cells exceeds a configurable threshold.
-   Uses the `rich` library for a clean and live-updating table display in the terminal.
-   Adds `get_historical_data` functionality to the Zerodha broker to fetch OI data.
-   Includes a new configuration file `strategy/configs/oi_tracker.yml` for easy customization.